### PR TITLE
Add fry.farm to DeFi Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Algorand is an open-source, proof of stake Blockchain and smart contract computi
 - [folks-router](https://github.com/Folks-Finance/folks-router) - Efficient swap routing SDK on Algorand by Folks Finance.
 - [Folks-Finance/algorand-js-sdk](https://github.com/Folks-Finance/folks-finance-js-sdk) - Official Folks Finance Algorand Protocol SDK.
 - [DorkFi](https://dork.fi/) - Cross-chain borrow/lend protocol on Algorand and Voi Network. Features overcollateralized lending, WAD stablecoin minting, and UNIT governance token.
+- [fry.farm](https://fry.farm/) - DeFi staking and yield farming platform by Fry Networks on Algorand and Voi. Stake FRY and ASA tokens, farm LP rewards, and swap with integrated routing.
 
 
 ### NFT Marketplaces


### PR DESCRIPTION
Adds fry.farm — Fry Networks' DeFi staking/yield-farming platform on Algorand (FRY ASA 2485314946; site https://fry.farm, docs https://docs.frynetworks.com, org https://github.com/Fry-Foundation/). Single entry in the DeFi Platforms section, format per contributing.md.