### PR TITLE
Add OpenChainBench to Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ Algorand is an open-source, proof of stake Blockchain and smart contract computi
 - [Allo Metrics](https://allo.info/metrics) - Algorand MainNet in numbers.
 - [Metrika](https://app.metrika.co/dashboard/algorand/) - Algorand network performance and account monitor.
 - [OnchainPulse ASA Safety Scanner](https://onchainpulse.theaslangroupllc.com) - Automated ASA token-safety check: clawback/freeze/manager authorities, default-frozen flag, holder concentration and Tinyman liquidity fused into a deterministic CLEAR/CAUTION/AVOID verdict, per-call via x402 (settles in Algorand USDC).
+- [OpenChainBench](https://openchainbench.com) - Independent RPC latency and L1 finality benchmarks for Algorand and 20+ other chains. Continuous measurements from 3 global regions, MIT licensed.
 
 ## SSI, DID and Verifiable Credentials
 


### PR DESCRIPTION
Adds OpenChainBench to the Infrastructure section. OCB provides continuous multi-region benchmarks for Algorand RPC endpoint latency and L1 finality, with cross-chain comparison. Open-source, MIT licensed harnesses, CC-BY-4.0 data. Actively maintained.