### PR TITLE
fix: point CONTRIBUTING at the actual Code of Conduct file

### DIFF
--- a/ARCHIVED.md
+++ b/ARCHIVED.md
@@ -31,6 +31,8 @@ The following markdown is the place for archived, old, deleted or unmaintained p
 - [Tenset Security](https://x.com/tenset_security) - Web3 Security Researchers team with a proven track record in discovering vulnerabilities within Algorand projects.
 - [AB2](https://ab2.gallery/) - Decentralized marketplace for crypto art assets secured on the Algorand blockchain created by @ab2_gallery.
 - [AlgoWorldExplorer](https://algoworldexplorer.io/) - NFT marketplace, explorer and gallery for AlgoWorld NFTs developed by @aorumbayev.
+- [AlgoWorld-Contracts](https://github.com/algoworldNFT/algoworld-contracts) - Collection of all smart contracts used by AlgoWorld, written in PyTeal.
+- [AlgoWorld-Swapper](https://github.com/algoworldNFT/algoworld-swapper) - Free and trustless ASA swapper, powered by Algorand Smart Signatures.
 - [ASA cafe](https://asa.cafe/) - Algorand Standard Asset platform and decentralized marketplace built by @CryptoRUSHGav.
 - [Grid](https://grid.zestbloom.com/) - The Grid is a lightweight, static site that executes in the clients frontend to retrieve an arbitrary list of live contracts for users to browse and interact with.
 - [Otherverse](https://otherverse.io/) - NFT collections marketplace.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contribution Guidelines
 
 Please note that this project is released with a
-[Contributor Code of Conduct](code-of-conduct.md). By participating in this
+[Contributor Code of Conduct](code_of_conduct.md). By participating in this
 project you agree to abide by its terms.
 
 ---

--- a/README.md
+++ b/README.md
@@ -167,8 +167,6 @@ Algorand is an open-source, proof of stake Blockchain and smart contract computi
 - [algorewards](https://algorewards.github.io/) - Free and unofficial Algorand governance reward calculator. Hosted on GitHub Pages.
 - [AlgoTables](https://algotables.github.io/) - A suite of tools designed to aid everyday hodlers of ALGO who participate in the Algorand ecosystem.
 - [algovanity](https://algovanity.com/) - Algorand Vanity Address Generator from [Ripe](https://github.com/Ripe/algovanity).
-- [AlgoWorld-Contracts](https://github.com/algoworldNFT/algoworld-contracts) - Collection of all smart contracts used by AlgoWorld, written in PyTeal.
-- [AlgoWorld-Swapper](https://github.com/algoworldNFT/algoworld-swapper) - Free and trustless ASA swapper, powered by Algorand Smart Signatures.
 - [arc3.xyz](https://github.com/barnjamin/arc3.xyz) - Dapp that can be used to mint ARC3 compliant NFTs.
 - [Auction Demo](https://github.com/algorand/auction-demo) - On-chain NFT auction using smart contracts.
 - [Automated Prediction Market Maker on Algorand](https://github.com/dspytdao/Algo_AMM) - Backend repository for an automated prediction market maker on Algorand.
@@ -424,7 +422,6 @@ Algorand is an open-source, proof of stake Blockchain and smart contract computi
 - [Immunebytes](https://www.immunebytes.com) - Secure your Algorand Smart Contract with credible security auditing solutions.
 - [KudelskiSecurity](https://kudelskisecurity.com) - Move your Blockchain project securely and successfully into production or onto mainnet. Company can help you assess, design, customize, deploy and manage Blockchain and digital ledger technology systems so you can confidently leverage security as a powerful differentiator in this dynamic market.
 - [Runtime Verification](https://runtimeverification.com/smartcontract) - Smart contract analysis and verification by the team who audited platforms like Algofi, FolksFinance, Yieldly and other prominent DeFi platforms in the ecosystem.
-- [Tenset Security](https://github.com/tenset-security/audits) - Comprising a team of Web3 Security Researchers, Tenset Security is dedicated to leaving no stone unturned in their pursuit of security excellence. They have a [proven track record of success](https://twitter.com/algoworld_nft/status/1691891473166279042) in discovering high-severity vulnerabilities specifically within Algorand projects, emphasizing their expertise and commitment to the Algorand ecosystem.
 - [UlamLabs](https://ulam.io/software-services/) - A Blockchain lab based in Poland, offering auditing services for Algorand smart contracts.
 - [Vantage Point Blockchain](https://www.vantagepoint.sg/contact-us) - Smart contract audits, crypto wallet audit and other penetration testing services in Algorand ecosystem with clients such as Folks.Finance, Pera, Algorand Foundation, Deflex (Defly/Alammex), GARD, Venue.One and others. Reports are signed by velocity.vantagepoint.algo and published at https://github.com/vantagepointreports/releases.
 

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at aorumbayev@pm.me. All
+reported by contacting the project team at https://x.com/awesome_algo. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
## Summary
- CONTRIBUTING.md linked to `code-of-conduct.md`, which does not exist. The file is `code_of_conduct.md`.

## Test plan
- [ ] Check Links / link-check no longer reports a missing `code-of-conduct.md`.
- [ ] CONTRIBUTING.md Code of Conduct link opens on GitHub.